### PR TITLE
:sparkles: Allow target override with annotation

### DIFF
--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -472,9 +472,13 @@ func (r *ServiceReconciler) configureCloudflare() error {
 	finalIngresses := make([]UnvalidatedIngressRule, 0, len(services)+1)
 
 	for _, service := range services {
+		targetService := decodeLabel(service.Labels[configServiceLabel], service)
+		if target, ok := service.Annotations[targetAnnotation]; ok {
+			targetService = target
+		}
 		finalIngresses = append(finalIngresses, UnvalidatedIngressRule{
 			Hostname: service.Labels[configHostnameLabel],
-			Service:  decodeLabel(service.Labels[configServiceLabel], service),
+			Service:  targetService,
 		})
 	}
 	// Catchall ingress

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -19,6 +19,8 @@ const (
 	clusterTunnelAnnotation = "cfargotunnel.com/cluster-tunnel"
 	// FQDN to create a DNS entry for and route traffic from internet on, defaults to Service name + cloudflare domain
 	fqdnAnnotation = "cfargotunnel.com/fqdn"
+	// Target can be used to override the target to send traffic to. Ex: Can be used to point to an ingress rather than the service directly
+	targetAnnotation = "cfargotunnel.com/target"
 
 	// Tunnel properties
 	isClusterTunnelAnnotation = "cfargotunnel.com/is-cluster-tunnel"


### PR DESCRIPTION
Introduces new annotation: "cfargotunnel.com/target"
Fixes #28 