### PR TITLE
Options to disable TLS checks and specify Root CA

### DIFF
--- a/api/v1alpha1/tunnel_types.go
+++ b/api/v1alpha1/tunnel_types.go
@@ -48,7 +48,7 @@ type CloudflareDetails struct {
 	Domain string `json:"domain,omitempty"`
 
 	//+kubebuilder:validation:Required
-	// Secret containing Cloudflare API key
+	// Secret containing Cloudflare API key/token
 	Secret string `json:"secret,omitempty"`
 
 	//+kubebuilder:validation:Optional
@@ -99,6 +99,15 @@ type TunnelSpec struct {
 	//+kubebuilder:validation:Optional
 	// Image sets the Cloudflared Image to use. Defaults to the image set during the release of the operator.
 	Image string `json:"image,omitempty"`
+
+	//+kubebuilder:default:=false
+	//+kubebuilder:validation:Optional
+	// NoTlsVerify disables origin TLS certificate checks when the endpoint is HTTPS.
+	NoTlsVerify bool `json:"noTlsVerify,omitempty"`
+
+	//+kubebuilder:validation:Optional
+	// OriginCaPool speficies the secret with tls.crt of the Root CA to be trusted when sending traffic to HTTPS endpoints
+	OriginCaPool string `json:"originCaPool,omitempty"`
 
 	//+kubebuilder:validation:Required
 	// Cloudflare Credentials

--- a/config/crd/bases/networking.cfargotunnel.com_tunnels.yaml
+++ b/config/crd/bases/networking.cfargotunnel.com_tunnels.yaml
@@ -79,7 +79,7 @@ spec:
                       for new tunnels only, or as an alternate to API Token
                     type: string
                   secret:
-                    description: Secret containing Cloudflare API key
+                    description: Secret containing Cloudflare API key/token
                     type: string
                 type: object
               existingTunnel:
@@ -110,6 +110,15 @@ spec:
                     description: Tunnel name to create on Cloudflare.
                     type: string
                 type: object
+              noTlsVerify:
+                default: false
+                description: NoTlsVerify disables origin TLS certificate checks when
+                  the endpoint is HTTPS.
+                type: boolean
+              originCaPool:
+                description: OriginCaPool speficies the secret with tls.crt of the
+                  Root CA to be trusted when sending traffic to HTTPS endpoints
+                type: string
               size:
                 default: 1
                 description: Size defines the number of Daemon pods to run for this

--- a/controllers/clustertunnel_controller.go
+++ b/controllers/clustertunnel_controller.go
@@ -312,7 +312,7 @@ func (r *ClusterTunnelReconciler) createManagedSecret() error {
 	managedSecret := &corev1.Secret{}
 	if err := r.Get(r.ctx, apitypes.NamespacedName{Name: r.tunnel.Name, Namespace: r.Namespace}, managedSecret); err != nil && apierrors.IsNotFound(err) {
 		// Define a new Secret
-		sec := r.secretForTunnel(r.tunnel, r.tunnelCreds)
+		sec := r.secretForTunnel()
 		r.log.Info("Creating a new Secret", "Secret.Namespace", sec.Namespace, "Secret.Name", sec.Name)
 		r.Recorder.Event(r.tunnel, corev1.EventTypeNormal, "CreatingSecret", "Creating Tunnel Secret")
 		err = r.Create(r.ctx, sec)
@@ -335,7 +335,7 @@ func (r *ClusterTunnelReconciler) createManagedConfigMap() error {
 	cfConfigMap := &corev1.ConfigMap{}
 	if err := r.Get(r.ctx, apitypes.NamespacedName{Name: r.tunnel.Name, Namespace: r.Namespace}, cfConfigMap); err != nil && apierrors.IsNotFound(err) {
 		// Define a new ConfigMap
-		cm := r.configMapForTunnel(r.tunnel)
+		cm := r.configMapForTunnel()
 		r.log.Info("Creating a new ConfigMap", "ConfigMap.Namespace", cm.Namespace, "ConfigMap.Name", cm.Name)
 		r.Recorder.Event(r.tunnel, corev1.EventTypeNormal, "Configuring", "Creating Tunnel ConfigMap")
 		err = r.Create(r.ctx, cm)
@@ -372,7 +372,7 @@ func (r *ClusterTunnelReconciler) createOrScaleManagedDeployment() (ctrl.Result,
 func (r *ClusterTunnelReconciler) createManagedDeployment(cfDeployment *appsv1.Deployment) (ctrl.Result, error) {
 	if err := r.Get(r.ctx, apitypes.NamespacedName{Name: r.tunnel.Name, Namespace: r.Namespace}, cfDeployment); err != nil && apierrors.IsNotFound(err) {
 		// Define a new deployment
-		dep := r.deploymentForTunnel(r.tunnel)
+		dep := r.deploymentForTunnel()
 		r.log.Info("Creating a new Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
 		r.Recorder.Event(r.tunnel, corev1.EventTypeNormal, "Deploying", "Creating Tunnel Deployment")
 		err = r.Create(r.ctx, dep)
@@ -433,10 +433,10 @@ func (r *ClusterTunnelReconciler) createManagedResources() (ctrl.Result, bool, e
 }
 
 // configMapForTunnel returns a tunnel ConfigMap object
-func (r *ClusterTunnelReconciler) configMapForTunnel(cfTunnel *networkingv1alpha1.ClusterTunnel) *corev1.ConfigMap {
-	ls := labelsForClusterTunnel(*cfTunnel)
+func (r *ClusterTunnelReconciler) configMapForTunnel() *corev1.ConfigMap {
+	ls := labelsForClusterTunnel(*r.tunnel)
 	initialConfigBytes, _ := yaml.Marshal(Configuration{
-		TunnelId:     cfTunnel.Status.TunnelId,
+		TunnelId:     r.tunnel.Status.TunnelId,
 		SourceFile:   "/etc/cloudflared/creds/credentials.json",
 		Metrics:      "0.0.0.0:2000",
 		NoAutoUpdate: true,
@@ -447,41 +447,41 @@ func (r *ClusterTunnelReconciler) configMapForTunnel(cfTunnel *networkingv1alpha
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cfTunnel.Name,
+			Name:      r.tunnel.Name,
 			Namespace: r.Namespace,
 			Labels:    ls,
 		},
 		Data: map[string]string{"config.yaml": string(initialConfigBytes)},
 	}
 	// Set Tunnel instance as the owner and controller
-	ctrl.SetControllerReference(cfTunnel, cm, r.Scheme)
+	ctrl.SetControllerReference(r.tunnel, cm, r.Scheme)
 	return cm
 }
 
 // secretForTunnel returns a tunnel Secret object
-func (r *ClusterTunnelReconciler) secretForTunnel(cfTunnel *networkingv1alpha1.ClusterTunnel, tunnelCreds string) *corev1.Secret {
-	ls := labelsForClusterTunnel(*cfTunnel)
+func (r *ClusterTunnelReconciler) secretForTunnel() *corev1.Secret {
+	ls := labelsForClusterTunnel(*r.tunnel)
 	sec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cfTunnel.Name,
+			Name:      r.tunnel.Name,
 			Namespace: r.Namespace,
 			Labels:    ls,
 		},
-		StringData: map[string]string{"credentials.json": tunnelCreds},
+		StringData: map[string]string{"credentials.json": r.tunnelCreds},
 	}
 	// Set Tunnel instance as the owner and controller
-	ctrl.SetControllerReference(cfTunnel, sec, r.Scheme)
+	ctrl.SetControllerReference(r.tunnel, sec, r.Scheme)
 	return sec
 }
 
 // deploymentForTunnel returns a tunnel Deployment object
-func (r *ClusterTunnelReconciler) deploymentForTunnel(cfTunnel *networkingv1alpha1.ClusterTunnel) *appsv1.Deployment {
-	ls := labelsForClusterTunnel(*cfTunnel)
-	replicas := cfTunnel.Spec.Size
+func (r *ClusterTunnelReconciler) deploymentForTunnel() *appsv1.Deployment {
+	ls := labelsForClusterTunnel(*r.tunnel)
+	replicas := r.tunnel.Spec.Size
 
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cfTunnel.Name,
+			Name:      r.tunnel.Name,
 			Namespace: r.Namespace,
 			Labels:    ls,
 		},
@@ -527,13 +527,13 @@ func (r *ClusterTunnelReconciler) deploymentForTunnel(cfTunnel *networkingv1alph
 					Volumes: []corev1.Volume{{
 						Name: "creds",
 						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: cfTunnel.Name},
+							Secret: &corev1.SecretVolumeSource{SecretName: r.tunnel.Name},
 						},
 					}, {
 						Name: "config",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{Name: cfTunnel.Name},
+								LocalObjectReference: corev1.LocalObjectReference{Name: r.tunnel.Name},
 								Items: []corev1.KeyToPath{{
 									Key:  "config.yaml",
 									Path: "config.yaml",
@@ -546,7 +546,7 @@ func (r *ClusterTunnelReconciler) deploymentForTunnel(cfTunnel *networkingv1alph
 		},
 	}
 	// Set Tunnel instance as the owner and controller
-	ctrl.SetControllerReference(cfTunnel, dep, r.Scheme)
+	ctrl.SetControllerReference(r.tunnel, dep, r.Scheme)
 	return dep
 }
 

--- a/controllers/tunnel_controller.go
+++ b/controllers/tunnel_controller.go
@@ -474,6 +474,50 @@ func (r *TunnelReconciler) deploymentForTunnel() *appsv1.Deployment {
 	ls := labelsForTunnel(*r.tunnel)
 	replicas := r.tunnel.Spec.Size
 
+	args := []string{"tunnel", "--config", "/etc/cloudflared/config/config.yaml", "run"}
+	volumes := []corev1.Volume{{
+		Name: "creds",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{SecretName: r.tunnel.Name},
+		},
+	}, {
+		Name: "config",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: r.tunnel.Name},
+				Items: []corev1.KeyToPath{{
+					Key:  "config.yaml",
+					Path: "config.yaml",
+				}},
+			},
+		},
+	}}
+	volumeMounts := []corev1.VolumeMount{{
+		Name:      "config",
+		MountPath: "/etc/cloudflared/config",
+		ReadOnly:  true,
+	}, {
+		Name:      "creds",
+		MountPath: "/etc/cloudflared/creds",
+		ReadOnly:  true,
+	}}
+	if r.tunnel.Spec.NoTlsVerify {
+		args = append(args, "--no-tls-verify")
+	}
+	if r.tunnel.Spec.OriginCaPool != "" {
+		args = append(args, "--origin-ca-pool", "/etc/cloudflared/certs/tls.crt")
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "certs",
+			MountPath: "/etc/cloudflared/certs",
+			ReadOnly:  true,
+		})
+		volumes = append(volumes, corev1.Volume{
+			Name: "creds",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: r.tunnel.Spec.OriginCaPool},
+			},
+		})
+	}
 
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -494,7 +538,7 @@ func (r *TunnelReconciler) deploymentForTunnel() *appsv1.Deployment {
 					Containers: []corev1.Container{{
 						Image: r.tunnel.Spec.Image,
 						Name:  "cloudflared",
-						Args:  []string{"tunnel", "--config", "/etc/cloudflared/config/config.yaml", "run"},
+						Args:  args,
 						LivenessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
 								HTTPGet: &corev1.HTTPGetAction{
@@ -506,37 +550,13 @@ func (r *TunnelReconciler) deploymentForTunnel() *appsv1.Deployment {
 							InitialDelaySeconds: 10,
 							PeriodSeconds:       10,
 						},
-						VolumeMounts: []corev1.VolumeMount{{
-							Name:      "config",
-							MountPath: "/etc/cloudflared/config",
-							ReadOnly:  true,
-						}, {
-							Name:      "creds",
-							MountPath: "/etc/cloudflared/creds",
-							ReadOnly:  true,
-						}},
+						VolumeMounts: volumeMounts,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{"memory": resource.MustParse("30Mi"), "cpu": resource.MustParse("10m")},
 							Limits:   corev1.ResourceList{"memory": resource.MustParse("256Mi"), "cpu": resource.MustParse("500m")},
 						},
 					}},
-					Volumes: []corev1.Volume{{
-						Name: "creds",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: r.tunnel.Name},
-						},
-					}, {
-						Name: "config",
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{Name: r.tunnel.Name},
-								Items: []corev1.KeyToPath{{
-									Key:  "config.yaml",
-									Path: "config.yaml",
-								}},
-							},
-						},
-					}},
+					Volumes: volumes,
 				},
 			},
 		},


### PR DESCRIPTION
This introduces two new fields in the spec which are useful when the target is serving HTTPS. 
* `noTlsVerify` allows you to skip TLS checks for self signed certificates. 
* `originCaPool` allows you to select a Secret containing the Root CA who signed the certificate for the HTTPS endpoints.
Fixes #30