### PR TITLE
Better default protocol selection logic

### DIFF
--- a/api/v1alpha1/tunnel_types.go
+++ b/api/v1alpha1/tunnel_types.go
@@ -111,7 +111,7 @@ type TunnelSpec struct {
 
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:default:="http_status:404"
-	// FallbackTarget speficies the target for requests that do not match an ingress. It can be pointed to the IngressController for using without the service controller. Defaults to http_status:404
+	// FallbackTarget speficies the target for requests that do not match an ingress. Defaults to http_status:404
 	FallbackTarget string `json:"fallbackTarget,omitempty"`
 
 	//+kubebuilder:validation:Required

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -433,12 +433,14 @@ func (r ServiceReconciler) getConfigForService(tunnelDomain string, service *cor
 	} else if servicePort.Protocol == corev1.ProtocolTCP {
 		// Default protocol selection logic
 		switch servicePort.Port {
-		case 80:
-			serviceProto = tunnelProtoHTTP
+		case 22:
+			serviceProto = tunnelProtoSSH
 		case 443:
 			serviceProto = tunnelProtoHTTPS
+		case 3389:
+			serviceProto = tunnelProtoRDP
 		default:
-			serviceProto = tunnelProtoTCP
+			serviceProto = tunnelProtoHTTP
 		}
 	} else if servicePort.Protocol == corev1.ProtocolUDP {
 		serviceProto = tunnelProtoUDP


### PR DESCRIPTION
The most common use case for this operator would be on HTTP traffic which usually runs on pods with ports other than 80.

So, the port selection logic defaults to HTTP. Also added SSH and RDP ports to their corresponding defaults.