### PR TITLE
Add proxy support in CRD

### DIFF
--- a/api/v1alpha1/tunnelbinding_types.go
+++ b/api/v1alpha1/tunnelbinding_types.go
@@ -80,7 +80,7 @@ type TunnelBindingSubjectSpec struct {
 	// ProxyType configures the proxy type.
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:default:=""
-	//+kubebuilder:validation:Enum:=;socks
+	//+kubebuilder:validation:Enum:="";"socks"
 	ProxyType string `json:"proxyType,omitempty"`
 }
 

--- a/api/v1alpha1/tunnelbinding_types.go
+++ b/api/v1alpha1/tunnelbinding_types.go
@@ -56,11 +56,32 @@ type TunnelBindingSubjectSpec struct {
 	//+kubebuilder:validation:Optional
 	CaPool string `json:"caPool,omitempty"`
 
-	// NoTlsVerify sisables TLS verification for this service.
+	// NoTlsVerify disables TLS verification for this service.
 	// Only useful if the protocol is HTTPS.
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:default:=false
 	NoTlsVerify bool `json:"noTlsVerify"`
+
+	// cloudflared starts a proxy server to translate HTTP traffic into TCP when proxying, for example, SSH or RDP.
+
+	// ProxyAddress configures the listen address for that proxy
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:default:="127.0.0.1"
+	//+kubebuilder:validation:Pattern="((^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))$)|(^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))$))"
+	ProxyAddress string `json:"proxyAddress,omitempty"`
+
+	// ProxyPort configures the listen port for that proxy
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:default:=0
+	//+kubebuilder:validation:Minimum:=0
+	//+kubebuilder:validation:Maximum:=65535
+	ProxyPort uint `json:"proxyPort,omitempty"`
+
+	// ProxyType configures the proxy type.
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:default:=""
+	//+kubebuilder:validation:Enum:=;socks
+	ProxyType string `json:"proxyType,omitempty"`
 }
 
 // TunnelRef defines the Tunnel TunnelBinding connects to

--- a/config/crd/bases/networking.cfargotunnel.com_tunnelbindings.yaml
+++ b/config/crd/bases/networking.cfargotunnel.com_tunnelbindings.yaml
@@ -117,7 +117,8 @@ spec:
                       default: ""
                       description: ProxyType configures the proxy type.
                       enum:
-                      - ;socks
+                      - ""
+                      - socks
                       type: string
                     target:
                       description: Target specified where the tunnel should proxy

--- a/config/crd/bases/networking.cfargotunnel.com_tunnelbindings.yaml
+++ b/config/crd/bases/networking.cfargotunnel.com_tunnelbindings.yaml
@@ -90,7 +90,7 @@ spec:
                       type: string
                     noTlsVerify:
                       default: false
-                      description: NoTlsVerify sisables TLS verification for this
+                      description: NoTlsVerify disables TLS verification for this
                         service. Only useful if the protocol is HTTPS.
                       type: boolean
                     protocol:
@@ -100,6 +100,24 @@ spec:
                         and 445, rdp for 3389 and ssh for 22 if the service has a
                         TCP port. The only available option for a UDP port is udp,
                         which is default.
+                      type: string
+                    proxyAddress:
+                      default: 127.0.0.1
+                      description: ProxyAddress configures the listen address for
+                        that proxy
+                      pattern: ((^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))$)|(^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))$))
+                      type: string
+                    proxyPort:
+                      default: 0
+                      description: ProxyPort configures the listen port for that proxy
+                      maximum: 65535
+                      minimum: 0
+                      type: integer
+                    proxyType:
+                      default: ""
+                      description: ProxyType configures the proxy type.
+                      enum:
+                      - ;socks
                       type: string
                     target:
                       description: Target specified where the tunnel should proxy

--- a/controllers/cloudflare_configuration.go
+++ b/controllers/cloudflare_configuration.go
@@ -4,6 +4,7 @@ import (
 	"time"
 )
 
+// https://github.com/cloudflare/cloudflared/blob/master/config/configuration.go
 // Configuration is a cloudflared configuration yaml model
 type Configuration struct {
 	TunnelId      string                   `yaml:"tunnel"`

--- a/controllers/tunnelbinding_controller.go
+++ b/controllers/tunnelbinding_controller.go
@@ -569,6 +569,9 @@ func (r *TunnelBindingReconciler) configureCloudflareDaemon() error {
 
 			originRequest := OriginRequestConfig{}
 			originRequest.NoTLSVerify = &subject.Spec.NoTlsVerify
+			originRequest.ProxyAddress = &subject.Spec.ProxyAddress
+			originRequest.ProxyPort = &subject.Spec.ProxyPort
+			originRequest.ProxyType = &subject.Spec.ProxyType
 			if caPool := subject.Spec.CaPool; caPool != "" {
 				caPath := fmt.Sprintf("/etc/cloudflared/certs/%s", caPool)
 				originRequest.CAPool = &caPath


### PR DESCRIPTION
Fixes #74 

Adds three new fields `ProxyAddress`, `ProxyPort` and `ProxyType` to the `TunnelBindingSubject.spec`.