### PR TITLE
Add path to service

### DIFF
--- a/api/v1alpha1/tunnelbinding_types.go
+++ b/api/v1alpha1/tunnelbinding_types.go
@@ -46,6 +46,11 @@ type TunnelBindingSubjectSpec struct {
 	//+kubebuilder:validation:Optional
 	Protocol string `json:"protocol,omitempty"`
 
+	// Path specifies a regular expression for to match on the request for http/https services
+	// If a rule does not specify a path, all paths will be matched.
+	//+kubebuilder:validation:Optional
+	Path string `json:"path,omitempty"`
+
 	// Target specified where the tunnel should proxy to.
 	// Defaults to the form of <protocol>://<service.metadata.name>.<service.metadata.namespace>.svc:<port>
 	//+kubebuilder:validation:Optional

--- a/config/crd/bases/networking.cfargotunnel.com_tunnelbindings.yaml
+++ b/config/crd/bases/networking.cfargotunnel.com_tunnelbindings.yaml
@@ -93,6 +93,11 @@ spec:
                       description: NoTlsVerify disables TLS verification for this
                         service. Only useful if the protocol is HTTPS.
                       type: boolean
+                    path:
+                      description: Path specifies a regular expression for to match
+                        on the request for http/https services If a rule does not
+                        specify a path, all paths will be matched.
+                      type: string
                     protocol:
                       description: Protocol specifies the protocol for the service.
                         Should be one of http, https, tcp, udp, ssh or rdp. Defaults

--- a/controllers/tunnelbinding_controller.go
+++ b/controllers/tunnelbinding_controller.go
@@ -574,7 +574,6 @@ func (r *TunnelBindingReconciler) configureCloudflareDaemon() error {
 			} else {
 				targetService = binding.Status.Services[i].Target
 			}
-
 			originRequest := OriginRequestConfig{}
 			originRequest.NoTLSVerify = &subject.Spec.NoTlsVerify
 			originRequest.ProxyAddress = &subject.Spec.ProxyAddress
@@ -588,6 +587,7 @@ func (r *TunnelBindingReconciler) configureCloudflareDaemon() error {
 			finalIngresses = append(finalIngresses, UnvalidatedIngressRule{
 				Hostname:      binding.Status.Services[i].Hostname,
 				Service:       targetService,
+				Path:          subject.Spec.Path,
 				OriginRequest: originRequest,
 			})
 		}


### PR DESCRIPTION
cloudflare allows for path-based [matching](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/local-management/ingress/#matching-traffic), this would allow exposing/pointing just specific paths to specific services