### PR TITLE
feat: allow changing cloudflared protocol

### DIFF
--- a/api/v1alpha1/tunnel_types.go
+++ b/api/v1alpha1/tunnel_types.go
@@ -114,6 +114,11 @@ type TunnelSpec struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	//+kubebuilder:validation:Optional
+	//+kubebuilder:default:="auto"
+	// Protocol specifies the protocol to use for the tunnel. Defaults to auto. Options are "auto", "quic" and "http2"
+	Protocol string `json:"protocol,omitempty"`
+
+	//+kubebuilder:validation:Optional
 	//+kubebuilder:default:="http_status:404"
 	// FallbackTarget speficies the target for requests that do not match an ingress. Defaults to http_status:404
 	FallbackTarget string `json:"fallbackTarget,omitempty"`

--- a/api/v1alpha1/tunnel_types.go
+++ b/api/v1alpha1/tunnel_types.go
@@ -114,6 +114,7 @@ type TunnelSpec struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	//+kubebuilder:validation:Optional
+	//+kubebuilder:validation:Enum={"auto","quic","http2"}
 	//+kubebuilder:default:="auto"
 	// Protocol specifies the protocol to use for the tunnel. Defaults to auto. Options are "auto", "quic" and "http2"
 	Protocol string `json:"protocol,omitempty"`

--- a/config/crd/bases/networking.cfargotunnel.com_clustertunnels.yaml
+++ b/config/crd/bases/networking.cfargotunnel.com_clustertunnels.yaml
@@ -139,6 +139,10 @@ spec:
                 default: auto
                 description: Protocol specifies the protocol to use for the tunnel.
                   Defaults to auto. Options are "auto", "quic" and "http2"
+                enum:
+                - auto
+                - quic
+                - http2
                 type: string
               size:
                 default: 1

--- a/config/crd/bases/networking.cfargotunnel.com_clustertunnels.yaml
+++ b/config/crd/bases/networking.cfargotunnel.com_clustertunnels.yaml
@@ -135,6 +135,11 @@ spec:
                   certs as needed to be referred in the service annotation) of the
                   Root CA to be trusted when sending traffic to HTTPS endpoints
                 type: string
+              protocol:
+                default: auto
+                description: Protocol specifies the protocol to use for the tunnel.
+                  Defaults to auto. Options are "auto", "quic" and "http2"
+                type: string
               size:
                 default: 1
                 description: Size defines the number of Daemon pods to run for this

--- a/config/crd/bases/networking.cfargotunnel.com_tunnels.yaml
+++ b/config/crd/bases/networking.cfargotunnel.com_tunnels.yaml
@@ -139,6 +139,10 @@ spec:
                 default: auto
                 description: Protocol specifies the protocol to use for the tunnel.
                   Defaults to auto. Options are "auto", "quic" and "http2"
+                enum:
+                - auto
+                - quic
+                - http2
                 type: string
               size:
                 default: 1

--- a/config/crd/bases/networking.cfargotunnel.com_tunnels.yaml
+++ b/config/crd/bases/networking.cfargotunnel.com_tunnels.yaml
@@ -135,6 +135,11 @@ spec:
                   certs as needed to be referred in the service annotation) of the
                   Root CA to be trusted when sending traffic to HTTPS endpoints
                 type: string
+              protocol:
+                default: auto
+                description: Protocol specifies the protocol to use for the tunnel.
+                  Defaults to auto. Options are "auto", "quic" and "http2"
+                type: string
               size:
                 default: 1
                 description: Size defines the number of Daemon pods to run for this

--- a/controllers/reconciler.go
+++ b/controllers/reconciler.go
@@ -411,8 +411,9 @@ func deploymentForTunnel(r GenericTunnelReconciler) *appsv1.Deployment {
 	replicas := r.GetTunnel().GetSpec().Size
 	nodeSelector := nodeSelectorsForTunnel(r.GetTunnel())
 	tolerations := r.GetTunnel().GetSpec().Tolerations
+	protocol := r.GetTunnel().GetSpec().Protocol
 
-	args := []string{"tunnel", "--config", "/etc/cloudflared/config/config.yaml", "--metrics", "0.0.0.0:2000", "run"}
+	args := []string{"tunnel", "--protocol", protocol, "--config", "/etc/cloudflared/config/config.yaml", "--metrics", "0.0.0.0:2000", "run"}
 	volumes := []corev1.Volume{{
 		Name: "creds",
 		VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
Hi @adyanth! Another configuration addition PR here for changing which protocol to use with the cloudflared tunnel, as #73 is still quite far away.

This PR introduces a new key named `protocol` which sets the `--protocol` argument of cloudflared binary. It is backwards compatible and doesn't cause any changes to existing configurations.