### PR TITLE
#105: update default image

### DIFF
--- a/api/v1alpha1/tunnel_types.go
+++ b/api/v1alpha1/tunnel_types.go
@@ -91,7 +91,7 @@ type TunnelSpec struct {
 	// Size defines the number of Daemon pods to run for this tunnel
 	Size int32 `json:"size,omitempty"`
 
-	//+kubebuilder:default:="cloudflare/cloudflared:2022.12.1"
+	//+kubebuilder:default:="cloudflare/cloudflared:2024.9.1"
 	//+kubebuilder:validation:Optional
 	// Image sets the Cloudflared Image to use. Defaults to the image set during the release of the operator.
 	Image string `json:"image,omitempty"`

--- a/bundle/manifests/networking.cfargotunnel.com_clustertunnels.yaml
+++ b/bundle/manifests/networking.cfargotunnel.com_clustertunnels.yaml
@@ -105,7 +105,7 @@ spec:
                   do not match an ingress. Defaults to http_status:404
                 type: string
               image:
-                default: cloudflare/cloudflared:2022.12.1
+                default: cloudflare/cloudflared:2024.9.1
                 description: Image sets the Cloudflared Image to use. Defaults to
                   the image set during the release of the operator.
                 type: string

--- a/bundle/manifests/networking.cfargotunnel.com_tunnels.yaml
+++ b/bundle/manifests/networking.cfargotunnel.com_tunnels.yaml
@@ -105,7 +105,7 @@ spec:
                   do not match an ingress. Defaults to http_status:404
                 type: string
               image:
-                default: cloudflare/cloudflared:2022.12.1
+                default: cloudflare/cloudflared:2024.9.1
                 description: Image sets the Cloudflared Image to use. Defaults to
                   the image set during the release of the operator.
                 type: string

--- a/config/crd/bases/networking.cfargotunnel.com_clustertunnels.yaml
+++ b/config/crd/bases/networking.cfargotunnel.com_clustertunnels.yaml
@@ -107,7 +107,7 @@ spec:
                   do not match an ingress. Defaults to http_status:404
                 type: string
               image:
-                default: cloudflare/cloudflared:2022.12.1
+                default: cloudflare/cloudflared:2024.9.1
                 description: Image sets the Cloudflared Image to use. Defaults to
                   the image set during the release of the operator.
                 type: string

--- a/config/crd/bases/networking.cfargotunnel.com_tunnels.yaml
+++ b/config/crd/bases/networking.cfargotunnel.com_tunnels.yaml
@@ -107,7 +107,7 @@ spec:
                   do not match an ingress. Defaults to http_status:404
                 type: string
               image:
-                default: cloudflare/cloudflared:2022.12.1
+                default: cloudflare/cloudflared:2024.9.1
                 description: Image sets the Cloudflared Image to use. Defaults to
                   the image set during the release of the operator.
                 type: string

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,7 @@ spec:
 
   # cloudflared configuration
   fallbackTarget: http_status:404           # The default service to point cloudflared to. Defaults to http_status:404
-  image: cloudflare/cloudflared:2022.3.1    # Image to run. Used for running an up-to-date image. Can be swapped out to an arm based image if needed
+  image: cloudflare/cloudflared:2024.9.1    # Image to run. Used for running an up-to-date image. Can be swapped out to an arm based image if needed
   noTlsVerify: false                        # Disables the TLS verification to backend services globally
   originCaPool: homelab-ca                  # Secret containing CA certificates to trust. Must contain tls.crt to be trusted globally and optionally other certificates (see the caPool service annotation for usage)
   size: 1                                   # Replica count for the tunnel deployment


### PR DESCRIPTION
Fixes #105. Updates default image from `cloudflare/cloudflared:2022.12.1` to `cloudflare/cloudflared:2024.9.1` 