### PR TITLE
feat: add http2Origin to TunnelBinding subject spec

### DIFF
--- a/api/v1alpha1/tunnelbinding_types.go
+++ b/api/v1alpha1/tunnelbinding_types.go
@@ -67,6 +67,12 @@ type TunnelBindingSubjectSpec struct {
 	//+kubebuilder:default:=false
 	NoTlsVerify bool `json:"noTlsVerify"`
 
+	// Http2Origin makes the service attempt to connect to origin using HTTP2.
+	// Origin must be configured as https.
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:default:=false
+	Http2Origin bool `json:"http2Origin"`
+
 	// cloudflared starts a proxy server to translate HTTP traffic into TCP when proxying, for example, SSH or RDP.
 
 	// ProxyAddress configures the listen address for that proxy

--- a/bundle/manifests/networking.cfargotunnel.com_tunnelbindings.yaml
+++ b/bundle/manifests/networking.cfargotunnel.com_tunnelbindings.yaml
@@ -86,6 +86,11 @@ spec:
                         If specifying this, make sure to use the same domain that
                         the tunnel belongs to. This is not validated and used as provided
                       type: string
+                    http2Origin:
+                      default: false
+                      description: Http2Origin makes the service attempt to connect to origin
+                        using HTTP2. Origin must be configured as https.
+                      type: boolean
                     noTlsVerify:
                       default: false
                       description: NoTlsVerify sisables TLS verification for this

--- a/config/crd/bases/networking.cfargotunnel.com_tunnelbindings.yaml
+++ b/config/crd/bases/networking.cfargotunnel.com_tunnelbindings.yaml
@@ -88,6 +88,11 @@ spec:
                         If specifying this, make sure to use the same domain that
                         the tunnel belongs to. This is not validated and used as provided
                       type: string
+                    http2Origin:
+                      default: false
+                      description: Http2Origin makes the service attempt to connect to origin
+                        using HTTP2. Origin must be configured as https.
+                      type: boolean
                     noTlsVerify:
                       default: false
                       description: NoTlsVerify disables TLS verification for this

--- a/controllers/cloudflare_configuration.go
+++ b/controllers/cloudflare_configuration.go
@@ -54,6 +54,8 @@ type OriginRequestConfig struct {
 	// Will allow any certificate from the origin to be accepted.
 	// Note: The connection from your machine to Cloudflare's Edge is still encrypted.
 	NoTLSVerify *bool `yaml:"noTLSVerify,omitempty"`
+	// Attempt to connect to origin using HTTP2. Origin must be configured as https.
+	Http2Origin *bool `yaml:"http2Origin,omitempty"`
 	// Disables chunked transfer encoding.
 	// Useful if you are running a WSGI server.
 	DisableChunkedEncoding *bool `yaml:"disableChunkedEncoding,omitempty"`

--- a/controllers/tunnelbinding_controller.go
+++ b/controllers/tunnelbinding_controller.go
@@ -576,6 +576,7 @@ func (r *TunnelBindingReconciler) configureCloudflareDaemon() error {
 			}
 			originRequest := OriginRequestConfig{}
 			originRequest.NoTLSVerify = &subject.Spec.NoTlsVerify
+			originRequest.Http2Origin = &subject.Spec.Http2Origin
 			originRequest.ProxyAddress = &subject.Spec.ProxyAddress
 			originRequest.ProxyPort = &subject.Spec.ProxyPort
 			originRequest.ProxyType = &subject.Spec.ProxyType


### PR DESCRIPTION
This PR adds the HTTP2 Connection option to the TunnelBinding configuration, which is required to get grpc to work.

See https://github.com/cloudflare/cloudflared/issues/491#issuecomment-1643233485