### PR TITLE
write example document for using cloudflared with a reverse proxy

### DIFF
--- a/docs/examples/tunnel-with-reverse-proxy/README.md
+++ b/docs/examples/tunnel-with-reverse-proxy/README.md
@@ -139,8 +139,9 @@ apiVersion: networking.cfargotunnel.com/v1alpha1
 kind: TunnelBinding
 metadata:
   name: authelia
+  namespace: authelia
 subjects:
-  - name: authelia # maps to the fqdn authelia.<domain>
+  - name: authelia # the fqdn authelia.<domain> maps to this service
 tunnelRef:
   kind: ClusterTunnel
   name: example-tunnel

--- a/docs/examples/tunnel-with-reverse-proxy/README.md
+++ b/docs/examples/tunnel-with-reverse-proxy/README.md
@@ -6,7 +6,7 @@
 
 Cloudflare tunnels can be used as a reverse proxy, or can forward traffic to an existing reverse proxy.
 This example shows how to configure cloudflared using the cloudflare-operator to front a reverse proxy. 
-In effect, we are using it as a layer 7 or layer 4 load balancer depending on whether we forward TCP/UDP or HTTP/HTTPS traffic.
+In effect, we are using it as a layer 4 or 7 load balancer depending on whether we forward TCP/UDP or HTTP/HTTPS traffic respectively.
 
 This configuration has a few use cases:
 - You have significant existing reverse proxy configuration, which you may or may not want to migrate to cloudflared.

--- a/docs/examples/tunnel-with-reverse-proxy/README.md
+++ b/docs/examples/tunnel-with-reverse-proxy/README.md
@@ -75,10 +75,7 @@ Notes:
 > **Ensure that you have kubectl, kustomize, and helm installed.**
 
 1. Configure a secret with your API token or API key, as described in [the getting started guide](../../getting-started.md#cloudflare-tokens)
-2. Deploy the cloudflare operator
-```shell
- kustomize build ../../../config/default | kubectl apply -f -
-```
+2. Deploy the cloudflare operator as described in [the getting started guide](../../getting-started.md#deploy-the-operator)
 3. Replace all placeholder values formatted `<like-this>`.
    - in `manifests/cloudflare-operator`
       - `<email-address>`: the email address associated with the cloudflare zone.

--- a/docs/examples/tunnel-with-reverse-proxy/README.md
+++ b/docs/examples/tunnel-with-reverse-proxy/README.md
@@ -146,13 +146,13 @@ tunnelRef:
 apiVersion: networking.cfargotunnel.com/v1alpha1
 kind: TunnelBinding
 metadata:
-  name: ingress-nginx
-subjects:
   # At this time cloudflare-operator does not deterministically sort wildcards to the end of cloudflared's config file.
   # This is important because cloudflared goes through the list in order, and this ingress being before the authelia ingress
   # would mean authelia is impossible to reach.
-  # By prefixing with `zz_` we ensure this is the last route in the cloudflared config file
-  - name: zz_wildcard
+  # By prefixing with `zz-` we ensure this is the last route in the cloudflared config file
+  name: zz-ingress-nginx
+subjects:
+  - name: wildcard
     spec:
       fqdn: "*.<domain>"
       target: https://ingress-nginx-controller.ingress-nginx.svc.cluster.local:443

--- a/docs/examples/tunnel-with-reverse-proxy/README.md
+++ b/docs/examples/tunnel-with-reverse-proxy/README.md
@@ -15,6 +15,27 @@ This configuration has a few use cases:
 - You want to keep your reverse proxy configuration modular, so that you can use any load balancer implementation
 - you use a service mesh with its own ingress implementation
 
+```
++----------------------+
+|   internet users     |
++----------------------+
+           |
+           v
++----------------------+
+|  cloudflare tunnel   |
++----------------------+
+           |
+           v
++----------------------+
+|    reverse proxy     |
++----------------------+
+     |           |
+     v           v
++---------+ +----------+
+| App #1  | |  App #2  |
++---------+ +----------+
+```
+
 ## What have we got here
 
 In this example we will:

--- a/docs/examples/tunnel-with-reverse-proxy/README.md
+++ b/docs/examples/tunnel-with-reverse-proxy/README.md
@@ -148,7 +148,11 @@ kind: TunnelBinding
 metadata:
   name: ingress-nginx
 subjects:
-  - name: wildcard
+  # At this time cloudflare-operator does not deterministically sort wildcards to the end of cloudflared's config file.
+  # This is important because cloudflared goes through the list in order, and this ingress being before the authelia ingress
+  # would mean authelia is impossible to reach.
+  # By prefixing with `zz_` we ensure this is the last route in the cloudflared config file
+  - name: zz_wildcard
     spec:
       fqdn: "*.<domain>"
       target: https://ingress-nginx-controller.ingress-nginx.svc.cluster.local:443

--- a/docs/examples/tunnel-with-reverse-proxy/README.md
+++ b/docs/examples/tunnel-with-reverse-proxy/README.md
@@ -13,8 +13,8 @@ This configuration has a few use cases:
   This configuration allows additional routes to be added with a tunnel binding to use this reverse proxy in combination with other routes.
 - You require reverse proxy functionality that cloudflared does not have
 - You want to keep your reverse proxy configuration modular, so that you can use any load balancer implementation
-- you use a service mesh with its own ingress implementation
-
+- You use a service mesh with its own ingress implementation
+- You have multiple load balancers pointing at your ingress. For example a lab might include metallb + DNS entries so that you are not traversing the internet when on the same network as your cluster
 ```
 +----------------------+
 |   internet users     |

--- a/docs/examples/tunnel-with-reverse-proxy/README.md
+++ b/docs/examples/tunnel-with-reverse-proxy/README.md
@@ -1,0 +1,139 @@
+# Bring your own reverse proxy
+
+> This builds on [the getting started guide](../../getting-started.md), and it is recommended to read that first.
+
+## Motivation
+
+Cloudflare tunnels can be used as a reverse proxy, or can forward traffic to an existing reverse proxy.
+This example shows how to configure cloudflared using the cloudflare-operator to front a reverse proxy. 
+In effect, we are using it as a layer 7 or layer 4 load balancer depending on whether we forward TCP/UDP or HTTP/HTTPS traffic.
+
+This configuration has a few use cases:
+- You have significant existing reverse proxy configuration, which you may or may not want to migrate to cloudflared.
+  This configuration allows additional routes to be added with a tunnel binding to use this reverse proxy in combination with other routes.
+- You require reverse proxy functionality that cloudflared does not have
+- You want to keep your reverse proxy configuration modular, so that you can use any load balancer implementation
+- you use a service mesh with its own ingress implementation
+
+## What have we got here
+
+In this example we will:
+1. Deploy cloudflare-operator and configure a cluster tunnel (this would also work with a regular tunnel resource).
+2. Deploy ingress-nginx as a reference reverse proxy, and configure the created cluster tunnel to point to ingress-nginx.
+3. Deploy an example application, and configure it behind nginx with an ingress resource
+   
+Doing so will allow you to use the cloudflare operator as a shim to whatever ingress method you choose.
+One can change the ingress implementation at will and use e.g. gateway API, a different ingress, etc
+
+Notes:
+- We use a cluster tunnel, but one can equally use a tunnel resource in the same way.
+- We do not use https with the reverse proxy for simplicity. 
+  The example deployment yaml includes commented snippets one can use to enable https.
+
+```
+.
+├── README.md                   # this document
+└── manifests                   # contains all manifests from this example
+    ├── cloudflare-operator     # contains manifests for configuring cloudflare-operator
+    │   ├── tunnel-binding.yaml    
+    │   └── cluster-tunnel.yaml
+    ├── hello                   # a reference application, you would replace this with your own application
+    │   ├── deployment.yaml
+    │   ├── ingress.yaml
+    │   └── service.yaml    
+    └── ingress-nginx           # this example deploys ingress-nginx as the reverse proxy
+        ├── kustomization.yaml
+        ├── namespace.yaml
+        └── values.yaml
+```
+
+## Steps
+
+> All steps assume you are working from the directory this README is in.
+
+> **Ensure that you have kubectl, kustomize, and helm installed.**
+
+1. Configure a secret with your API token or API key, as described in [the getting started guide](../../getting-started.md#cloudflare-tokens)
+2. Deploy the cloudflare operator
+```shell
+ kustomize build ../../../config/default | kubectl apply -f -
+```
+3. Replace all placeholder values formatted `<like-this>`.
+   - in `manifests/cloudflare-operator`
+      - `<email-address>`: the email address associated with the cloudflare zone.
+      - `<domain>`: the domain associated with the cloudflare zone you are managing.
+      - `<secret-name>`: the name of the secret containing your cloudflare credentials.
+      - `<account-id>`: the account ID associated with the cloudflare zone you are managing.
+   - in `manifests/hello/ingress.yaml`
+     - `<domain>`: the domain associated with the cloudflare zone you are managing.
+4. deploy the cluster tunnel and tunnelbinding
+```shell
+kubectl apply -f manifests/cloudflare-operator/
+```
+5. deploy the reverse proxy
+```shell
+kustomize build --enable-helm manifests/ingress-nginx | kubectl apply -f - 
+```
+6. deploy the example application
+```shell
+kubectl apply -f manifests/hello/
+```
+7. You should now be able to access the service on `hello.<domain>`
+
+## Extending this example
+
+Now that we are using an arbitrary reverse proxy for routing traffic into the cluster, we can configure it as if we were using a cloud load balancer.
+This means you can use whatever constructs are available to your reverse proxy implementation.
+
+### Custom SSO
+
+One can configure SSO with a custom provider.
+This example uses ingress-nginx and authelia
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: <app>
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # in order to direct cloudflare tunnel to ingress-nginx, we have a single tunnelBinding resource in ingress-nginx.
+    # this is what controls ingress to ingress-nginx and allows us to put 2fa infront of apps that don't support it natively.
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-url: "http://authelia.authelia.svc.cluster.local:8080/api/authz/auth-request"
+    nginx.ingress.kubernetes.io/auth-signin: "https://authelia.<domain>?rm=$request_method"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Remote-User,Remote-Name,Remote-Groups,Remote-Email"
+--- SNIP ---
+```
+
+### Using cloudflared for routing as well as ingress-nginx
+
+Using this approach does not prohibit additional routes.
+This is useful if you are migrating to/from one approach, or have different requirements for different endpoints.
+For example, you may want some endpoints to bypass your reverse proxy for some reason.
+
+```yaml
+apiVersion: networking.cfargotunnel.com/v1alpha1
+kind: TunnelBinding
+metadata:
+  name: authelia
+subjects:
+  - name: authelia # maps to the fqdn authelia.<domain>
+tunnelRef:
+  kind: ClusterTunnel
+  name: example-tunnel
+---
+apiVersion: networking.cfargotunnel.com/v1alpha1
+kind: TunnelBinding
+metadata:
+  name: ingress-nginx
+subjects:
+  - name: wildcard
+    spec:
+      fqdn: "*.<domain>"
+      target: https://ingress-nginx-controller.ingress-nginx.svc.cluster.local:443
+tunnelRef:
+  kind: ClusterTunnel
+  name: example-tunnel
+```

--- a/docs/examples/tunnel-with-reverse-proxy/manifests/cloudflare-operator/cluster-tunnel.yaml
+++ b/docs/examples/tunnel-with-reverse-proxy/manifests/cloudflare-operator/cluster-tunnel.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.cfargotunnel.com/v1alpha1
+kind: ClusterTunnel
+metadata:
+  name: example-tunnel
+spec:
+  newTunnel:
+    name: example-tunnel
+  size: 1
+  cloudflare:
+    email: <email-address>
+    domain: <domain>
+    secret: <secret-name>
+    accountId: <account-id>

--- a/docs/examples/tunnel-with-reverse-proxy/manifests/cloudflare-operator/tunnel-binding.yaml
+++ b/docs/examples/tunnel-with-reverse-proxy/manifests/cloudflare-operator/tunnel-binding.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.cfargotunnel.com/v1alpha1
+kind: TunnelBinding
+metadata:
+  name: ingress-nginx
+subjects:
+  # this example assumes you are exposing services with your reverse proxy without certificates.
+  # In general this is not recommended
+  - name: wildcard
+    spec:
+      fqdn: "*.<domain>"
+      target: http://ingress-nginx-controller.ingress-nginx.svc.cluster.local:80
+      noTlsVerify: true
+
+#  # this example assumes you are generating certificates for your reverse proxy using e.g. cert-manager
+#  # you should use only one of the following two configurations, not both.
+#  - name: wildcard
+#    spec:
+#      fqdn: "*.<domain>"
+#      target: https://ingress-nginx-controller.ingress-nginx.svc.cluster.local:443
+
+tunnelRef:
+  kind: ClusterTunnel
+  name: example-tunnel

--- a/docs/examples/tunnel-with-reverse-proxy/manifests/hello/deployment.yaml
+++ b/docs/examples/tunnel-with-reverse-proxy/manifests/hello/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-demo
+  labels:
+    app: hello-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello-demo
+  template:
+    metadata:
+      labels:
+        app: hello-demo
+    spec:
+      containers:
+        - name: hello
+          image: nginxdemos/hello:latest
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 30

--- a/docs/examples/tunnel-with-reverse-proxy/manifests/hello/ingress.yaml
+++ b/docs/examples/tunnel-with-reverse-proxy/manifests/hello/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hello-demo
+  annotations: {}
+#    # uncomment if you are using cert-manager for TLS
+#    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: hello.<domain>
+      http:
+        paths:
+          - path: /(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: hello-svc
+                port:
+                  number: 80
+#  # optional: enable if you have cert manager or TLS secret
+#  tls:
+#    - hosts:
+#        - hello.example.com
+#      secretName: hello-tls

--- a/docs/examples/tunnel-with-reverse-proxy/manifests/hello/service.yaml
+++ b/docs/examples/tunnel-with-reverse-proxy/manifests/hello/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-demo
+  labels:
+    app: hello-demo
+spec:
+  type: ClusterIP
+  selector:
+    app: hello-demo
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/docs/examples/tunnel-with-reverse-proxy/manifests/ingress-nginx/kustomization.yaml
+++ b/docs/examples/tunnel-with-reverse-proxy/manifests/ingress-nginx/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ingress-nginx
+
+resources:
+  - resources/namespace.yaml
+
+helmCharts:
+  - includeCRDs: true
+    name: ingress-nginx
+    namespace: ingress-nginx
+    releaseName: ingress-nginx
+    repo: https://kubernetes.github.io/ingress-nginx
+    valuesFile: values.yaml
+    version: 4.12.1

--- a/docs/examples/tunnel-with-reverse-proxy/manifests/ingress-nginx/namespace.yaml
+++ b/docs/examples/tunnel-with-reverse-proxy/manifests/ingress-nginx/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx
+spec: {}

--- a/docs/examples/tunnel-with-reverse-proxy/manifests/ingress-nginx/values.yaml
+++ b/docs/examples/tunnel-with-reverse-proxy/manifests/ingress-nginx/values.yaml
@@ -5,11 +5,11 @@ controller:
   service:
     type: ClusterIP
 
-  # this config allows your services to read the IP address from connecting clients
-  config:
-    enable-real-ip: "true"                     # tell nginx to trust the header we pick up from Cloudflare
-    forwarded-for-header: "CF-Connecting-IP"   # remap this header (from CF tunnel) to x-forwarded-for
-    use-forwarded-headers: "true"              # keep/pass X-Forwarded-*
-    # trust setting the x-forwarded-for header from all pods in k8s.
-    # Ideally this would be only the CF tunnel pods.
-    proxy-real-ip-cidr: <your-cluster-pod-cidr>
+#   # this config allows your services to read the IP address from connecting clients
+#   config:
+#     enable-real-ip: "true"                     # tell nginx to trust the header we pick up from Cloudflare
+#     forwarded-for-header: "CF-Connecting-IP"   # remap this header (from CF tunnel) to x-forwarded-for
+#     use-forwarded-headers: "true"              # keep/pass X-Forwarded-*
+#     # trust setting the x-forwarded-for header from all pods in k8s.
+#     # Ideally this would be only the CF tunnel pods.
+#     proxy-real-ip-cidr: <your-cluster-pod-cidr>

--- a/docs/examples/tunnel-with-reverse-proxy/manifests/ingress-nginx/values.yaml
+++ b/docs/examples/tunnel-with-reverse-proxy/manifests/ingress-nginx/values.yaml
@@ -1,0 +1,15 @@
+defaultBackend:
+  enabled: true
+
+controller:
+  service:
+    type: ClusterIP
+
+  # this config allows your services to read the IP address from connecting clients
+  config:
+    enable-real-ip: "true"                     # tell nginx to trust the header we pick up from Cloudflare
+    forwarded-for-header: "CF-Connecting-IP"   # remap this header (from CF tunnel) to x-forwarded-for
+    use-forwarded-headers: "true"              # keep/pass X-Forwarded-*
+    # trust setting the x-forwarded-for header from all pods in k8s.
+    # Ideally this would be only the CF tunnel pods.
+    proxy-real-ip-cidr: <your-cluster-pod-cidr>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ kubectl apply -k https://github.com/adyanth/cloudflare-operator/config/default
 # Correct full format as per https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
 kubectl apply -k 'https://github.com/adyanth/cloudflare-operator.git//config/default?ref=main'
 # If you need a specific version, follow the below syntax. Example shown for v0.4.1
-kubectl apply -k 'https://github.com/adyanth/cloudflare-operator.git//config/default?ref=v0.4.1'
+kubectl apply -k 'https://github.com/adyanth/cloudflare-operator.git//config/default?ref=v0.12.0'
 ```
 
 ## Create a Custom ClusterTunnel Resource


### PR DESCRIPTION
This documents how I use cloudflare-operator, I figured this is the use case I know the most about so it makes sense for me to start here

I'm also using this PR to float an approach for organising docs. In this PR we introduce an examples directory inside the docs directory, which becomes a place to document and guide readers on the expected use cases for this tool. This use case is called `tunnel-with-reverse-proxy` for example

Moving forward this could help us identify new use cases people come to us with, and attempts to provide us with a little more structure as new custom resources are created and use cases arise

What do you think of this approach? If you like it, I will follow up with similar changes for existing documentation