### PR TITLE
Allow building (but not pushing) the container from forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,17 +40,13 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: |
-          (github.event_name == 'pull_request' && github.event.pull_request.user.login == github.repository_owner) ||
-          github.actor == github.repository_owner
+        if: github.event.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
-        if: |
-          (github.event_name == 'pull_request' && github.event.pull_request.user.login == github.repository_owner) ||
-          github.actor == github.repository_owner
+        if: github.event.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -60,7 +56,7 @@ jobs:
         with:
           context: .
           platforms: ${{ github.event.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          push: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.user.login == github.repository_owner) || github.actor == github.repository_owner) }}
+          push: ${{ github.event.ref_type == 'tag' || github.event_name == 'workflow_dispatch' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Docker Hub Description

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,6 @@ on:
 
 jobs:
   docker:
-    # Need's repo owner login creds
-    if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.user.login == github.repository_owner) ||
-      github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,11 +40,17 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
+        if: |
+          (github.event_name == 'pull_request' && github.event.pull_request.user.login == github.repository_owner) ||
+          github.actor == github.repository_owner
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: |
+          (github.event_name == 'pull_request' && github.event.pull_request.user.login == github.repository_owner) ||
+          github.actor == github.repository_owner
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -58,7 +60,7 @@ jobs:
         with:
           context: .
           platforms: ${{ github.event.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          push: true
+          push: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.user.login == github.repository_owner) || github.actor == github.repository_owner) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Docker Hub Description


### PR DESCRIPTION
Allows us to see that the binary at least builds in CI. 

Have I gotten your expected logic right, you only push on explicit tag creation and on manual workflows?