### PR TITLE
whilst code coverage reporter fails on forks, don't run on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           path: cover.out
   code_coverage:
     name: "Code coverage report"
-    if: github.event_name == 'pull_request' # Do not run when workflow is triggered by push to main branch
+    if: github.event.pull_request.head.repo.full_name == github.repository # run only when the PR’s branch lives in this repo
     runs-on: ubuntu-latest
     needs: test
     permissions:


### PR DESCRIPTION
https://github.com/fgrosse/go-coverage-report?tab=readme-ov-file#limitations