### PR TITLE
fix: use correct namespace for leader election

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,7 +76,7 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.StringVar(&clusterResourceNamespace, "cluster-resource-namespace", "cloudflare-operator-system", "The default namespace for cluster scoped resources.")
+	flag.StringVar(&clusterResourceNamespace, "cluster-resource-namespace", "", "The default namespace for cluster scoped resources.")
 	flag.BoolVar(&overwriteUnmanaged, "overwrite-unmanaged-dns", false, "Overwrite DNS records that do not have a corresponding managed TXT record, defaults to false.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
 		"Enable leader election for controller manager. "+


### PR DESCRIPTION
Currently, when the operator is deployed into a custom namespace the leader election does not work because of a hard-coded default value for the `LeaderElectionNamespace`: https://github.com/adyanth/cloudflare-operator/blob/da0c5f0fdd2733cf3b215c7c93331195ea939114/cmd/main.go#L79

In fact the Kubebuilder book FAQs recommend to set the field only in non-cluster deployments for development purposes: https://book.kubebuilder.io/faq#after-make-run-i-see-errors-like-unable-to-find-leader-election-namespace-not-running-in-cluster

As an easy fix the default value could be removed.