### PR TITLE
Pin unpinned-action references across 3 workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,13 +15,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup Go 1.24
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: 1.24
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa
         with:
           only-new-issues: true
           version: v2.1.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@b2391d37b4157fa4aa2e118d643f417910ff3242
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -35,24 +35,24 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         if: github.event.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         if: github.event.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: .
           platforms: ${{ github.event.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
@@ -61,7 +61,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       - name: Docker Hub Description
         if: github.event.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@dc67fad7001ef9e8e3c124cb7a64e16d0a63d864
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -69,7 +69,7 @@ jobs:
           readme-filepath: ./README.md
           short-description: "Cloudflare Operator Controller Manager"
       - name: Setup Go 1.24
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         if: github.event.ref_type == 'tag'
         with:
           go-version: 1.24

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - name: Setup Go 1.24
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: 1.24
       - name: Test
         run: make test
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: code-coverage
           path: cover.out
@@ -33,8 +33,8 @@ jobs:
       actions:       read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: fgrosse/go-coverage-report@v1.1.1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
+      - uses: fgrosse/go-coverage-report@ba3f798d6f32b9b16faea37cc7192261bb25b192
         with:
           coverage-artifact-name: "code-coverage"
           coverage-file-name: "cover.out"


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

## Why these matter

**Why pin to a SHA** (`unpinned-action`)

Each unpinned action reference can be force-moved to attacker-controlled code by the action's owner or anyone who compromises their account — exactly what happened in the tj-actions/changed-files attack (CVE-2025-30066, Mar 2025). Pinning to a 40-character commit SHA freezes the exact reviewed code.

Reference: CWE-829 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/reference/security/secure-use) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025)

### `.github/workflows/lint.yml`

- 🟠 MED `golangci/golangci-lint-action` (job `lint`)
- ⚪ LOW `actions/checkout` (job `lint`)
- ⚪ LOW `actions/setup-go` (job `lint`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,13 +15,13 @@
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup Go 1.24
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: 1.24
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa
         with:
           only-new-issues: true
           version: v2.1.5
```

</details>

### `.github/workflows/release.yml`

- 🟠 MED `docker/metadata-action` (job `docker`)
- 🟠 MED `docker/setup-qemu-action` (job `docker`)
- 🟠 MED `docker/setup-buildx-action` (job `docker`)
- 🟠 MED `docker/login-action` (job `docker`)
- 🟠 MED `docker/login-action` (job `docker`)
- 🟠 MED `docker/build-push-action` (job `docker`)
- 🟠 MED `peter-evans/dockerhub-description` (job `docker`)
- ⚪ LOW `actions/checkout` (job `docker`)
- ⚪ LOW `actions/setup-go` (job `docker`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@b2391d37b4157fa4aa2e118d643f417910ff3242
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -35,24 +35,24 @@
             type=semver,pattern={{major}}
             type=sha
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         if: github.event.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         if: github.event.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
... (23 more diff lines — see Files changed)
```

</details>

### `.github/workflows/test.yml`

- 🟠 MED `fgrosse/go-coverage-report` (job `code_coverage`)
- ⚪ LOW `actions/checkout` (job `test`)
- ⚪ LOW `actions/setup-go` (job `test`)
- ⚪ LOW `actions/upload-artifact` (job `test`)
- ⚪ LOW `actions/checkout` (job `code_coverage`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,15 @@
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - name: Setup Go 1.24
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: 1.24
       - name: Test
         run: make test
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: code-coverage
           path: cover.out
@@ -33,8 +33,8 @@
       actions:       read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: fgrosse/go-coverage-report@v1.1.1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
+      - uses: fgrosse/go-coverage-report@ba3f798d6f32b9b16faea37cc7192261bb25b192
         with:
           coverage-artifact-name: "code-coverage"
           coverage-file-name: "cover.out"
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
